### PR TITLE
Update DBSM service URLs to public endpoints

### DIFF
--- a/docs/tools-and-services/dbsm.md
+++ b/docs/tools-and-services/dbsm.md
@@ -28,13 +28,13 @@ single PostgreSQL + PostGIS database. Two schemas partition the data by dataset 
 
 The stack is composed of five services:
 
-| Service | Port | Access |
-|---------|------|--------|
-| PostgREST API | `3501` | Public (no auth) |
-| Swagger UI | `3504` | Public (no auth) |
-| GeoServer | `3503` | `admin` / configured in `.env` |
-| PgAdmin | `3502` | Configured in `.env` |
-| PostgreSQL | `3500` | `dbsm_admin` / configured in `.env` |
+| Service | Public URL | Internal URL | Credentials |
+|---------|-----------|--------------|-------------|
+| PostgREST API | [dbsm-api.test.ctic.es](https://dbsm-api.test.ctic.es) | `http://localhost:3501` | None |
+| Swagger UI | [dbsm-swagger.test.ctic.es](https://dbsm-swagger.test.ctic.es) | `http://localhost:3504` | None |
+| GeoServer | [dbsm-geo.test.ctic.es/geoserver/web](https://dbsm-geo.test.ctic.es/geoserver/web) | `http://localhost:3503/geoserver/web` | `admin` / `geoserver` |
+| PgAdmin | [dbsm-admin.test.ctic.es](https://dbsm-admin.test.ctic.es) | `http://localhost:3502` | `user@domain.com` / `postgres` |
+| PostgreSQL | — (not exposed, binary protocol) | `localhost:3500` | `dbsm_admin` / `postgres` |
 
 The architecture and full setup guide are available in the
 [repository README](https://github.com/MODERATE-Project/DBSM_R2025_GeoService).
@@ -61,7 +61,7 @@ and click **Execute**. The response is displayed below with the status code and 
 > Functions that return building geometries can produce responses of tens of MB that
 > Swagger UI cannot render. To exclude the geometry column, append `?select=` to the URL:
 > ```
-> http://<host>:3501/rpc/buildings_in_bbox?select=fid,unique_id,source,area,height,use
+> https://dbsm-api.test.ctic.es/rpc/buildings_in_bbox?select=fid,unique_id,source,area,height,use
 > ```
 
 The available RPC functions are:
@@ -107,7 +107,7 @@ The v2 SLD style classifies buildings by height using five colour bands:
 The WMS endpoint pattern is:
 
 ```
-http://<host>:3503/geoserver/dbsm_v2/ows?service=WMS&version=1.3.0&request=GetCapabilities
+https://dbsm-geo.test.ctic.es/geoserver/dbsm_v2/ows?service=WMS&version=1.3.0&request=GetCapabilities
 ```
 
 ### QGIS Integration

--- a/docs/tools-and-services/index.md
+++ b/docs/tools-and-services/index.md
@@ -65,9 +65,9 @@ The _DBSM GeoService_ is a containerized geospatial microservice stack for manag
 
 - :fontawesome-brands-github: &nbsp; [Git repository](https://github.com/MODERATE-Project/DBSM_R2025_GeoService)
 - :fontawesome-solid-book: &nbsp; [Documentation](dbsm.md)
-- :fontawesome-solid-up-right-from-square: &nbsp; [REST API](http://newdevit.fundacionctic.org:3501)
-- :fontawesome-solid-up-right-from-square: &nbsp; [Swagger UI](http://newdevit.fundacionctic.org:3504)
-- :fontawesome-solid-up-right-from-square: &nbsp; [GeoServer](http://newdevit.fundacionctic.org:3503/geoserver/web)
+- :fontawesome-solid-up-right-from-square: &nbsp; [REST API](https://dbsm-api.test.ctic.es)
+- :fontawesome-solid-up-right-from-square: &nbsp; [Swagger UI](https://dbsm-swagger.test.ctic.es)
+- :fontawesome-solid-up-right-from-square: &nbsp; [GeoServer](https://dbsm-geo.test.ctic.es/geoserver/web)
 
 ## 💰 Measurement and Verification Tool
 


### PR DESCRIPTION
## Summary

- Updates `docs/tools-and-services/dbsm.md`: replaces the service table (previously Port + Access) with a three-column layout — **Public URL / Internal URL / Credentials** — reflecting the definitive deployment on `*.test.ctic.es`. Updates the Swagger tip example URL and the WMS endpoint pattern to use the public hostnames.
- Updates `docs/tools-and-services/index.md`: replaces the three quick-access links (REST API, Swagger UI, GeoServer) that pointed to `newdevit.fundacionctic.org:port` with the correct public URLs.

## Service access references

| Service | Public URL |
|---------|-----------|
| PostgREST API | https://dbsm-api.test.ctic.es |
| Swagger UI | https://dbsm-swagger.test.ctic.es |
| GeoServer | https://dbsm-geo.test.ctic.es/geoserver/web |
| PgAdmin | https://dbsm-admin.test.ctic.es |
| PostgreSQL | Not exposed (binary protocol) |